### PR TITLE
3 bug fixes

### DIFF
--- a/session_security/middleware.py
+++ b/session_security/middleware.py
@@ -56,11 +56,11 @@ class SessionSecurityMiddleware(object):
                 client_idle_for = int(request.GET['idleFor'])
             except ValueError:
                 return
-            
-            # Do not allow negative values since delta would be calculated incorrectly 
+
+            # Disallow negative values, causes problems with delta calculation
             if client_idle_for < 0:
                 client_idle_for = 0
-            
+
             if client_idle_for < server_idle_for:
                 # Client has more recent activity than we have in the session
                 last_activity = now - timedelta(seconds=client_idle_for)


### PR DESCRIPTION
- Added check for request.path to ensure idleFor parameter is processed only for session_security_ping url
- Assume a negative idleFor value means 0 to prevent a log out but if the value is negative
- Ignore non-integer idleFor values instead of throwing an exception
