### PR TITLE
Fix clock sync problems

### DIFF
--- a/session_security/middleware.py
+++ b/session_security/middleware.py
@@ -35,7 +35,7 @@ class SessionSecurityMiddleware(object):
         self.update_last_activity(request, now)
 
         delta = now - get_last_activity(request.session)
-        if delta.seconds >= EXPIRE_AFTER:
+        if delta.seconds >= EXPIRE_AFTER and delta.days >= 0:
             logout(request)
         elif request.path not in PASSIVE_URLS:
             set_last_activity(request.session, now)


### PR DESCRIPTION
When clocks are out of sync between hosts, improper logouts can occur. This stops this by not logging out when last activity is in the future in comparison to the local clock.
