### PR TITLE
Fixing import error that shows up under Django 1.5

### DIFF
--- a/session_security/urls.py
+++ b/session_security/urls.py
@@ -15,9 +15,9 @@ ie::
 
 """
 try:
-    from django.conf.urls.defaults import url, patterns
-except ImportError:
     from django.conf.urls import url, patterns
+except ImportError:
+    from django.conf.urls.defaults import url, patterns
 
 from .views import PingView
 


### PR DESCRIPTION
This `try: except:` block appears to be backwards. It should be trying the "new" import, and failing over to the old style if the new one is unavailable. Instead, it appears to be attempting the old one, and if that fails going to the new one. This resultis in the `except` block triggering every time under Django 1.6, and the base case executing under Django 1.5, which makes debugging interesting.

Given that the goal here is to support 1.6, with the option to fail back to 1.5 if needed, I believe it would make more sense to invert these two, as indicated in this pull request.
