### PR TITLE
Use consistent formatting for the datetime

### DIFF
--- a/session_security/utils.py
+++ b/session_security/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 def set_last_activity(session, dt):
     """ Set the last activity datetime as a string in the session. """
-    session['_session_security'] = dt.isoformat()
+    session['_session_security'] = dt.strftime('%Y-%m-%dT%H:%M:%S.%f')
 
 
 def get_last_activity(session):


### PR DESCRIPTION
This fixes a bug when the datetime has 0 microseconds. The isoformat() method strips the microsecond decimal when it's 0. This results in a ValueError exception when get_last_activity() tries to apply the srtptime format with ".%f".  Use the same format when setting as when getting to prevent this from happening. 

Example:

```
>>> from datetime import datetime
>>> dt1 = datetime(2014, 5, 15, 13, 30, 45, 413084)
>>> dt1.isoformat()
'2014-05-15T13:30:45.413084' # This will parse correctly
>>> dt2 = datetime(2014, 5, 15, 13, 30, 45, 0)
>>> dt2.isoformat()                           
'2014-05-15T13:30:45' # This will raise a ValueError exception
```

Additional details
http://bugs.python.org/issue19475
