### PR TITLE
Center the modal on the viewport

### DIFF
--- a/session_security/static/session_security/style.css
+++ b/session_security/static/session_security/style.css
@@ -1,6 +1,6 @@
 /* credit: http://www.csslab.cl/2008/01/30/ventana-modal-solo-con-css/ */
 .session_security_overlay {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;
@@ -13,7 +13,7 @@
 }
 
 .session_security_modal {
-    position: absolute;
+    position: fixed;
     top: 25%;
     left: 25%;
     width: 50%;


### PR DESCRIPTION
Change the position from `absolute` to `fixed` so that the overlay and the modal are centered on the viewport, rather than the page.  This ensures that the modal is always visible even on a longer page.
