### PR TITLE
fixes an edge bug discovered in multithreaded environments

### DIFF
--- a/session_security/utils.py
+++ b/session_security/utils.py
@@ -14,24 +14,23 @@ def get_last_activity(session):
     python datetime object.
     """
     try:
-        return datetime.strptime(session['_session_security'], '%Y-%m-%dT%H:%M:%S.%f')
+        return datetime.strptime(session['_session_security'],
+                '%Y-%m-%dT%H:%M:%S.%f')
     except AttributeError:
-        ##################################################################################
+        #################################################################
         # * this is an odd bug in python
-        #     bug report: http://bugs.python.org/issue7980
-        #     bug explained here: http://code-trick.com/python-bug-attribute-error-_strptime/
-        # * sometimes, in multithreaded enviroments, this will raise an AttributeError
-        #     in this case, we just return datetime.now(), so that we are not logged out
-        #
-        #   File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/session_security/middleware.py", line 34, in process_request
-        #     self.update_last_activity(request, now)
-        #   File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/session_security/middleware.py", line 52, in update_last_activity
+        # bug report: http://bugs.python.org/issue7980
+        # bug explained here:
+        # http://code-trick.com/python-bug-attribute-error-_strptime/
+        # * sometimes, in multithreaded enviroments, we get AttributeError
+        #     in this case, we just return datetime.now(),
+        #     so that we are not logged out
+        #   "./session_security/middleware.py", in update_last_activity
         #     last_activity = get_last_activity(request.session)
-        #   File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/session_security/utils.py", line 17, in get_last_activity
+        #   "./session_security/utils.py", in get_last_activity
         #     '%Y-%m-%dT%H:%M:%S.%f')
         #   AttributeError: _strptime
         #
-        ##################################################################################
+        #################################################################
 
         return datetime.now()
-


### PR DESCRIPTION
bug explained here: http://code-trick.com/python-bug-attribute-error-_strptime/
python bug report: http://bugs.python.org/issue7980

 File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 88, in get_response
    response = middleware_method(request)
  File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/session_security/middleware.py", line 34, in process_request
    self.update_last_activity(request, now)
  File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/session_security/middleware.py", line 52, in update_last_activity
    last_activity = get_last_activity(request.session)
  File "/Users/user/src/myapp/venv/lib/python2.7/site-packages/session_security/utils.py", line 17, in get_last_activity
    '%Y-%m-%dT%H:%M:%S.%f')
AttributeError: _strptime
