### PR TITLE
Use reverse_lazy in settings.py

### DIFF
--- a/session_security/settings.py
+++ b/session_security/settings.py
@@ -34,7 +34,7 @@ WARN_AFTER = getattr(settings, 'SESSION_SECURITY_WARN_AFTER', 540)
 
 PASSIVE_URLS = getattr(settings, 'SESSION_SECURITY_PASSIVE_URLS', [])
 PASSIVE_URLS += [
-    urlresolvers.reverse('session_security_ping'),
+    urlresolvers.reverse_lazy('session_security_ping'),
 ]
 
 if not getattr(settings, 'SESSION_EXPIRE_AT_BROWSER_CLOSE', False):


### PR DESCRIPTION
Hi!

  It's my first pull request, pardon my noob-ness :)

  I changed `settings.py` to use `reverse_lazy()` when calculating the `PASSIVE_URLS` list, since it seems that `settings.py` gets loaded before the final URLs are generated.

  You can recreate my issue using apache.  Serve your app from a virtual host with 
 `WSGIScriptAlias /prefix /path/to/wsgi.py`

  If you log the `request.path` in the middleware, you'll see
`/prefix/session_security/ping/`
  However the `PASSIVE_URLS` list will have
`/session_security/ping`

  Using `reverse_lazy` seems to fix the issue.

  Otherwise this works like a charm.  Thanks for a great solution to a problem!

Cheers,
-Matt
