### PR TITLE
<link> should not have an end tag

### DIFF
--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -15,7 +15,7 @@ It provides sensible defaults so you could start with just::
 {% if request.user.is_authenticated %}
 
     {# The modal dialog stylesheet, it's pretty light so it should be easy to hack #}
-    <link rel="stylesheet" type="text/css" href="{% static 'session_security/style.css' %}"></link>
+    <link rel="stylesheet" type="text/css" href="{% static 'session_security/style.css' %}">
 
     {# Include the template that actually contains the modal dialog #}
     {% include 'session_security/dialog.html' %}


### PR DESCRIPTION
Quoting [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link):
> As it is a void element, the start tag must be present and the end tag must not be present