### PR TITLE
form should be considered "clean" when reset

### DIFF
--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -39,7 +39,8 @@ yourlabs.SessionSecurity = function(options) {
     if (this.confirmFormDiscard) {
         window.onbeforeunload = $.proxy(this.onbeforeunload, this);
         $(document).on('change', ':input', $.proxy(this.formChange, this));
-        $(document).on('submit', 'form', $.proxy(this.formSubmit, this));
+        $(document).on('submit', 'form', $.proxy(this.formClean, this));
+        $(document).on('reset', 'form', $.proxy(this.formClean, this));
     }
 }
 
@@ -133,8 +134,8 @@ yourlabs.SessionSecurity.prototype = {
         $(e.target).closest('form').attr('data-dirty', true);
     },
 
-    // When a form is submited, unset data-dirty attribute.
-    formSubmit: function(e) {
+    // When a form is submitted or resetted, unset data-dirty attribute.
+    formClean: function(e) {
         $(e.target).removeAttr('data-dirty');
     }
 }


### PR DESCRIPTION
When the content of form is resetted, it should be considered "clean". Added reset event listener to remove "data-dirty" attribute. This help with Ajax call use case, avoiding "unsaved data" warning.