### PR TITLE
Throttle lastActivity updates to once per second

### DIFF
--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -66,7 +66,12 @@ yourlabs.SessionSecurity.prototype = {
 
     // Called by click, scroll, mousemove, keyup.
     activity: function() {
-        this.lastActivity = new Date();
+        var now = new Date();
+        if (now - this.lastActivity < 1000)
+            // Throttle these checks to once per second
+            return;
+
+        this.lastActivity = now;
 
         if (this.$warning.is(':visible')) {
             // Inform the server that the user came back manually, this should


### PR DESCRIPTION
When moving mouse around, script.js would do lots of

    this.$warning.is(':visible')

and 

    this.$warning.hide()

I think there's no harm to throttling these to at most once per second.
