### PR TITLE
added setting to disable confirm_form_discard

### DIFF
--- a/session_security/settings.py
+++ b/session_security/settings.py
@@ -30,7 +30,9 @@ import warnings
 from django.core import urlresolvers
 from django.conf import settings
 
-__all__ = ['EXPIRE_AFTER', 'WARN_AFTER', 'PASSIVE_URLS', 'CONFIRM_FORM_DISCARD']
+__all__ = [
+    'EXPIRE_AFTER', 'WARN_AFTER', 'PASSIVE_URLS', 'CONFIRM_FORM_DISCARD'
+]
 
 EXPIRE_AFTER = getattr(settings, 'SESSION_SECURITY_EXPIRE_AFTER', 600)
 

--- a/session_security/settings.py
+++ b/session_security/settings.py
@@ -16,6 +16,10 @@ PASSIVE_URLS
     it should not be used to update the user's last activity datetime.
     Overridable in ``settings.SESSION_SECURITY_PASSIVE_URLS``.
 
+CONFIRM_FORM_DISCARD
+    Enable or Disable form discard messages.
+    ``settings.SESSION_SECURITY_CONFIRM_FORM_DISCARD``.
+
 Note that this module will raise a warning if
 ``settings.SESSION_EXPIRE_AT_BROWSER_CLOSE`` is not True, because it makes no
 sense to use this app with ``SESSION_EXPIRE_AT_BROWSER_CLOSE`` to False.
@@ -26,7 +30,7 @@ import warnings
 from django.core import urlresolvers
 from django.conf import settings
 
-__all__ = ['EXPIRE_AFTER', 'WARN_AFTER', 'PASSIVE_URLS']
+__all__ = ['EXPIRE_AFTER', 'WARN_AFTER', 'PASSIVE_URLS', 'CONFIRM_FORM_DISCARD']
 
 EXPIRE_AFTER = getattr(settings, 'SESSION_SECURITY_EXPIRE_AFTER', 600)
 
@@ -36,6 +40,9 @@ PASSIVE_URLS = getattr(settings, 'SESSION_SECURITY_PASSIVE_URLS', [])
 PASSIVE_URLS += [
     urlresolvers.reverse('session_security_ping'),
 ]
+
+CONFIRM_FORM_DISCARD = getattr(
+    settings, 'SESSION_SECURITY_CONFIRM_FORM_DISCARD', False)
 
 if not getattr(settings, 'SESSION_EXPIRE_AT_BROWSER_CLOSE', False):
     warnings.warn('settings.SESSION_EXPIRE_AT_BROWSER_CLOSE is not True')

--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -26,11 +26,20 @@ It provides sensible defaults so you could start with just::
     {# Bootstrap a SessionSecurity instance as the sessionSecurity global variable #}
     {% localize off %}
         <script type="text/javascript">
+            var confirm_form_discard = {{ request|confirm_form_discard|yesno:"true,false" }};
+
+            if (confirm_form_discard){
+                var confirmFormDiscard = "{% trans 'You have unsaved changes in a form of this page.' %}";
+            }
+            else{
+                var confirmFormDiscard = false;
+            }
+
             var sessionSecurity = new yourlabs.SessionSecurity({
                 pingUrl: '{% url 'session_security_ping' %}',
                 warnAfter: {{ request|warn_after|unlocalize }},
                 expireAfter: {{ request|expire_after|unlocalize }},
-                confirmFormDiscard: "{% trans 'You have unsaved changes in a form of this page.' %}"
+                confirmFormDiscard: confirmFormDiscard
             });
         </script>
     {% endlocalize %}    

--- a/session_security/templatetags/session_security_tags.py
+++ b/session_security/templatetags/session_security_tags.py
@@ -1,6 +1,8 @@
 from django import template
 
-from session_security.settings import WARN_AFTER, EXPIRE_AFTER
+from session_security.settings import (
+    WARN_AFTER, EXPIRE_AFTER, CONFIRM_FORM_DISCARD
+)
 
 register = template.Library()
 
@@ -13,3 +15,8 @@ def expire_after(request):
 @register.filter
 def warn_after(request):
     return WARN_AFTER
+
+
+@register.filter
+def confirm_form_discard(request):
+    return CONFIRM_FORM_DISCARD


### PR DESCRIPTION
Added setting variable to allow globally disabling `confirm_form_discard`

Should address this issue https://github.com/yourlabs/django-session-security/issues/39