### PR TITLE
Remove Forbidden </link>.

### DIFF
--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -15,7 +15,7 @@ It provides sensible defaults so you could start with just::
 {% if request.user.is_authenticated %}
 
     {# The modal dialog stylesheet, it's pretty light so it should be easy to hack #}
-    <link rel="stylesheet" type="text/css" href="{% static 'session_security/style.css' %}"></link>
+    <link rel="stylesheet" type="text/css" href="{% static 'session_security/style.css' %}">
 
     {# Include the template that actually contains the modal dialog #}
     {% include 'session_security/dialog.html' %}


### PR DESCRIPTION
Link tags are forbidden by the HTML spec to have closing tags ([source](http://www.w3.org/TR/html4/struct/links.html#edef-LINK)).

This causes anything that's using this page to be invalid HTML & it causes Django's SimpleTestCase.assertInHTML to not work.