### PR TITLE
Fixed sphinx warning

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -7,7 +7,7 @@ every time you want to programaticaly trigger an activity.
 
 
 How to disable the "Are you sure you want to leave this page?" warning ?
-----------------------------------------------
+------------------------------------------------------------------------
 
 Include the JavaScript variable ``sessionSecurity.confirmFormDiscard = undefined;`` somewhere in your project *after* the plugin's JS. For example::
 


### PR DESCRIPTION
Fixed sphinx warning "docs/source/faq.rst:10: WARNING: Title underline too short."
This doesn't change the output.