### PR TITLE
Catch TypeError. This happens when upgrading from old versions and

### DIFF
--- a/session_security/utils.py
+++ b/session_security/utils.py
@@ -34,3 +34,6 @@ def get_last_activity(session):
         #################################################################
 
         return datetime.now()
+    except TypeError:
+        return datetime.now()
+


### PR DESCRIPTION
we have old sessions that has some old time formats. #62 