### PR TITLE
Encode logout response to JSON

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Requirements
 
 - Python 2.7 or 3
 - jQuery 1.7+
-- Django 1.4+
+- Django 1.7+
 - django.contrib.staticfiles or django-staticfiles (included in Pinax) or
   you're on your own
 

--- a/session_security/tests/test_views.py
+++ b/session_security/tests/test_views.py
@@ -26,13 +26,13 @@ class ViewsTestCase(test.TestCase):
         self.client.logout()
         self.client.get('/admin/')
         response = self.client.get('/session_security/ping/?idleFor=1')
-        self.assertEqual(response.content, six.b('logout'))
+        self.assertEqual(response.content, six.b('"logout"'))
 
     ping_provider = lambda x=None: (
         (1, 4, '1'),
         (3, 2, '2'),
         (5, 5, '5'),
-        (12, 14, 'logout', False),
+        (12, 14, '"logout"', False),
     )
 
     @data_provider(ping_provider)

--- a/session_security/views.py
+++ b/session_security/views.py
@@ -21,8 +21,10 @@ class PingView(generic.View):
     def get(self, request, *args, **kwargs):
         if '_session_security' not in request.session:
             # It probably has expired already
-            return http.HttpResponse('logout')
+            return http.HttpResponse('"logout"',
+                                     content_type='application/json')
 
         last_activity = get_last_activity(request.session)
         inactive_for = (datetime.now() - last_activity).seconds
-        return http.HttpResponse(inactive_for)
+        return http.HttpResponse(inactive_for,
+                                 content_type='application/json')


### PR DESCRIPTION
The logout response is supposed to go to `pong()` as defined in the JS, which then calls `this.expire()`, but that will not happen since the `logout` string is not quoted (JSON encoded). In all cases, jQuery will catch a `SyntaxError` exception when decoding the JSON response and then call the error callback.

I am seeing this error (or similar) if catch all AJAX errors:

```
SyntaxError: JSON Parse error: Unexpected identifier "logout"
```

This also adds `Content-Type: application/json` header to the response.

It is unnecessary to run any JSON encoder against the numeric response as a numeric literal (in general) is already valid JSON.

In Django 1.7+ it is possible to use` http.JsonResponse()` but I used the `json` module to stay compatible with 1.4+.

To monkey patch (1.7+):
```
# in a urls.py file define:
urlpatterns = [
    url(
        r'^ss/ping/$',
        PingView.as_view(), # your own PingView
        name='session_security_ping',
    ),
# ...
]

from datetime import datetime, timedelta
from django.views import generic
from django.http import JsonResponse
from session_security.utils import get_last_activity
class PingView(generic.View):
    def get(self, request, *args, **kwargs):
        if '_session_security' not in request.session:
            # It probably has expired already
            return JsonResponse('logout', safe=False)

        last_activity = get_last_activity(request.session)
        inactive_for = (datetime.now() - last_activity).seconds
        return JsonResponse(inactive_for, safe=False)
```