### PR TITLE
Django release dance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ env:
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django110
+  - TOXENV=py27-django111
   - TOXENV=py34-django17
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110
+  - TOXENV=py34-django111
 install:
   - pip install -U pip
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34}-django{17,18,19,110}
+envlist = py{27,34}-django{17,18,19,110,111}
 
 [testenv]
 usedevelop = true
@@ -14,7 +14,8 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    django110: https://github.com/django/django/archive/master.tar.gz
+    django110: Django>=1.10,<1.11
+    django111: https://github.com/django/django/archive/master.tar.gz
 setenv =
     PIP_ALLOW_EXTERNAL=true
     DJANGO_SETTINGS_MODULE=session_security.tests.project.settings


### PR DESCRIPTION
Actually, 1.11 is tested now but 1.10 is not anymore.

This patch makes the django version dance.