### PR TITLE
added compatibility with django 1.10

### DIFF
--- a/session_security/middleware.py
+++ b/session_security/middleware.py
@@ -13,12 +13,13 @@ from datetime import datetime, timedelta
 
 from django.contrib.auth import logout
 from django.core.urlresolvers import reverse
+from django.utils.deprecation import MiddlewareMixin
 
 from .utils import get_last_activity, set_last_activity
 from .settings import EXPIRE_AFTER, PASSIVE_URLS
 
 
-class SessionSecurityMiddleware(object):
+class SessionSecurityMiddleware(MiddlewareMixin):
     """
     In charge of maintaining the real 'last activity' time, and log out the
     user if appropriate.


### PR DESCRIPTION
In order to be compatible with the new middleware style classes of django 1.10, the middleware need to derive from the MiddlewareMixin. I have added this in this pull request.