### PR TITLE
Add a11y support to session security dialog

### DIFF
--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -63,7 +63,7 @@ yourlabs.SessionSecurity.prototype = {
     showWarning: function() {
         this.$warning.fadeIn('slow');
         this.$warning.attr('aria-hidden', 'false');
-        this.$warning.find('h3').focus()
+        $('.session_security_modal').focus();
     },
     
     // Called to hide the warning, for example if there has been activity on

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -63,6 +63,7 @@ yourlabs.SessionSecurity.prototype = {
     showWarning: function() {
         this.$warning.fadeIn('slow');
         this.$warning.attr('aria-hidden', 'false');
+        this.$warning.find('h3').focus()
     },
     
     // Called to hide the warning, for example if there has been activity on

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -62,12 +62,14 @@ yourlabs.SessionSecurity.prototype = {
     // seconds.
     showWarning: function() {
         this.$warning.fadeIn('slow');
+        this.$warning.attr('aria-hidden', 'false');
     },
     
     // Called to hide the warning, for example if there has been activity on
     // the server side - in another browser tab.
     hideWarning: function() {
         this.$warning.hide();
+        this.$warning.attr('aria-hidden', 'true');
     },
 
     // Called by click, scroll, mousemove, keyup.

--- a/session_security/templates/session_security/dialog.html
+++ b/session_security/templates/session_security/dialog.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div id="session_security_warning" class="session_security" style="display:none" aria-hidden="true">
+<div id="session_security_warning" class="session_security" style="display:none" aria-hidden="true" role="dialog">
     <div class="session_security_overlay"></div>
     <div class="session_security_modal">
         <h3>{% trans 'Your session is about to expire' %}</h3>

--- a/session_security/templates/session_security/dialog.html
+++ b/session_security/templates/session_security/dialog.html
@@ -4,7 +4,7 @@
     <div class="session_security_overlay"></div>
     <div class="session_security_modal" role="document" tabindex="-1">
         <h3>{% trans 'Your session is about to expire' %}</h3>
-        <p>{% trans 'Click to extend your session.' %}</p>
+        <p>{% trans 'Click or type to extend your session.' %}</p>
     </div>
 </div>
 

--- a/session_security/templates/session_security/dialog.html
+++ b/session_security/templates/session_security/dialog.html
@@ -2,7 +2,7 @@
 
 <div id="session_security_warning" class="session_security" style="display:none" aria-hidden="true" role="dialog">
     <div class="session_security_overlay"></div>
-    <div class="session_security_modal">
+    <div class="session_security_modal" role="document" tabindex="-1">
         <h3>{% trans 'Your session is about to expire' %}</h3>
         <p>{% trans 'Click to extend your session.' %}</p>
     </div>

--- a/session_security/templates/session_security/dialog.html
+++ b/session_security/templates/session_security/dialog.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div id="session_security_warning" class="session_security" style="display:none">
+<div id="session_security_warning" class="session_security" style="display:none" aria-hidden="true">
     <div class="session_security_overlay"></div>
     <div class="session_security_modal">
         <h3>{% trans 'Your session is about to expire' %}</h3>


### PR DESCRIPTION
This PR adds aria roles to the dialog, and a line of js to swap focus to the dialog when it appears.

I should note that missing from this PR is the ability to move focus back to its original location after the dialog is dismissed. I couldn't find out where I could capture `document.activeElement` such that it was pointing to the user's last focused element (as opposed to `<body>...</body>`. I imagine someone @yourlabs may be able to assist with that.

That said, this PR is a large improvement over not having the focus switched at all.