### PR TITLE
Call is_authenticated property instead of function for Django 2.0

### DIFF
--- a/session_security/middleware.py
+++ b/session_security/middleware.py
@@ -11,6 +11,7 @@ Make sure that it is placed **after** authentication middlewares.
 
 from datetime import datetime, timedelta
 
+import django
 from django.contrib.auth import logout
 from django.core.urlresolvers import reverse, resolve, Resolver404
 
@@ -51,7 +52,12 @@ class SessionSecurityMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """ Update last activity time or logout. """
-        if not request.user.is_authenticated:
+        if django.VERSION < (1, 10):
+            is_authenticated = request.user.is_authenticated()
+        else:
+            is_authenticated = request.user.is_authenticated
+
+        if not is_authenticated:
             return
 
         now = datetime.now()

--- a/session_security/middleware.py
+++ b/session_security/middleware.py
@@ -51,7 +51,7 @@ class SessionSecurityMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """ Update last activity time or logout. """
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return
 
         now = datetime.now()


### PR DESCRIPTION
This addresses the following warning:

```
/session_security/middleware.py:54: RemovedInDjango20Warning: Using user.is_authenticated() and user.is_anonymous() as a method is deprecated. Remove the parentheses to use it as an attribute.
  if not request.user.is_authenticated():
```