### PR TITLE
Check if session expired on activity

### DIFF
--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -86,17 +86,19 @@ yourlabs.SessionSecurity.prototype = {
         var idleFor = Math.floor((now - this.lastActivity) / 1000);
         this.lastActivity = now;
 
-        if (this.$warning.is(':visible')) {
-            // Inform the server that the user came back manually, this should
-            // block other browser tabs from expiring.
-            this.ping();
-        } else if (idleFor >= this.expireAfter) {
+        if (idleFor >= this.expireAfter) {
             // Enforces checking whether a user's session is expired. This 
             // ensures a user being redirected instead of waiting until nextPing. 
             this.expire();
         }
-
-        this.hideWarning();
+        
+        if (this.$warning.is(':visible')) {
+            // Inform the server that the user came back manually, this should
+            // block other browser tabs from expiring.
+            this.ping();
+            // The hideWarning should only be called when the warning is visible
+            this.hideWarning();
+        }
     },
 
     // Hit the PingView with the number of seconds since last activity.

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -84,11 +84,16 @@ yourlabs.SessionSecurity.prototype = {
             return;
 
         this.lastActivity = now;
+        var idleFor = Math.floor((new Date() - this.lastActivity) / 1000);
 
         if (this.$warning.is(':visible')) {
             // Inform the server that the user came back manually, this should
             // block other browser tabs from expiring.
             this.ping();
+        } else if (idleFor >= this.expireAfter) {
+            // Enforces checking whether a user's session is expired. This 
+            // ensures a user being redirected instead of waiting until nextPing. 
+            this.expire();
         }
 
         this.hideWarning();

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -83,8 +83,8 @@ yourlabs.SessionSecurity.prototype = {
             // Throttle these checks to once per second
             return;
 
+        var idleFor = Math.floor((now - this.lastActivity) / 1000);
         this.lastActivity = now;
-        var idleFor = Math.floor((new Date() - this.lastActivity) / 1000);
 
         if (this.$warning.is(':visible')) {
             // Inform the server that the user came back manually, this should


### PR DESCRIPTION
### The issue

We were first facing this problem when our customers experienced problems w/ our application inside Citrix. I assume this is because Citrix does not handle the javascript counting when it is idle. The session expired on the backend but any activity (i.e. scrolling, mouseEvents) extended the time (approximately 30-60s) until the user was redirected to the logout. We were also able to reproduce this (on osx at least) by putting it asleep.

### Reproducing
To reproduce this you can use the following:

```python
SESSION_SECURITY_EXPIRE_AFTER = 180
SESSION_SECURITY_WARN_AFTER = 120
```

After putting your macbook to sleep for more then 180s your session should be expired and the user should be redirected by the expire function. Instead the nextping is recalculated over the remaining time and until then the user won't be redirected but will be able to continue browsing until a hard refresh is done. So any ajax calls won't be triggered as the user isn't signed in but will still be able to be pressed by the user.

Hoping the issue is clear.
