### PR TITLE
update french translation

### DIFF
--- a/session_security/locale/fr/LC_MESSAGES/django.po
+++ b/session_security/locale/fr/LC_MESSAGES/django.po
@@ -15,15 +15,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: session_security/templates/session_security/all.html:32
+#: templates/session_security/all.html:32
 msgid "You have unsaved changes in a form of this page."
 msgstr ""
 "Vous avez des changements non sauvegardés dans un formulaire de cette page."
 
-#: session_security/templates/session_security/dialog.html:6
+#: templates/session_security/dialog.html:6
 msgid "Your session is about to expire"
 msgstr "Votre session est sur le point d'expirer"
 
-#: session_security/templates/session_security/dialog.html:7
+#: templates/session_security/dialog.html:7
 msgid "Click or type to extend your session."
 msgstr "Touchez la souris ou tapez votre clavier pour étendre la durée de votre session."

--- a/session_security/locale/fr/LC_MESSAGES/django.po
+++ b/session_security/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.0.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-19 16:28+0100\n"
+"POT-Creation-Date: 2018-10-23 11:41-0400\n"
 "PO-Revision-Date: 2013-02-19 16:26+0100\n"
 "Last-Translator: James Pic <jamespic@gmail.com>\n"
 "Language: French\n"
@@ -15,14 +15,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: templates/session_security/all.html:32
+#: session_security/templates/session_security/all.html:32
 msgid "You have unsaved changes in a form of this page."
-msgstr "Vous avez des changements non sauvegardés dans un formulaire de cette page."
+msgstr ""
+"Vous avez des changements non sauvegardés dans un formulaire de cette page."
 
-#: templates/session_security/dialog.html:6
+#: session_security/templates/session_security/dialog.html:6
 msgid "Your session is about to expire"
 msgstr "Votre session est sur le point d'expirer"
 
-#: templates/session_security/dialog.html:7
-msgid "Click to extend your session."
-msgstr "Touchez la souris pour étendre la durée de votre session."
+#: session_security/templates/session_security/dialog.html:7
+msgid "Click or type to extend your session."
+msgstr "Touchez la souris ou tapez votre clavier pour étendre la durée de votre session."


### PR DESCRIPTION
Most of the `.po` files have become out of date with the source, specifically when "or type" was added to "Click or type to extend your session."

This results in the "Your session is about to expire" popup to only be half-translated.

I've correctly updated the french translation.
