### PR TITLE
Added charset to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from setuptools import setup, find_packages, Command
 import os, sys
 


### PR DESCRIPTION
```
author='∞'
```
makes the file non ascii-7 and thus requires explicit charset definition. Not doing so breaks pybuilld:
```
I: pybuild base:217: python2.7 setup.py clean 
  File "setup.py", line 47
SyntaxError: Non-ASCII character '\xe2' in file setup.py on line 47, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
E: pybuild pybuild:338: clean: plugin distutils failed with: exit code=1: python2.7 setup.py clean 
```