### PR TITLE
Django 3.0 compatibility

### DIFF
--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -8,7 +8,7 @@ It provides sensible defaults so you could start with just::
 
 {% load session_security_tags %}
 {% load i18n l10n %}
-{% load static from staticfiles %}
+{% load static %}
 
 {# If the user is not authenticated then there is no session to secure ! #}
 {% if request.user.is_authenticated %}


### PR DESCRIPTION
{% load static %} has been the drop in replacement for {% load static from staticfiles %} since Django 1.10 and it has been deprecated for several versions. Django 3.0 removes the staticfiles template tag.

Unfortunately the testing matrix seems broken since sbo_selenium is no longer maintained. I can verify I manually tested that it works on Django 1.10-3.0, but to fix the tests would likely require a near full rewrite.