### PR TITLE
Added seconds countdown if "counterElementID" is set

### DIFF
--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -135,7 +135,7 @@ yourlabs.SessionSecurity.prototype = {
         if (idleFor >= this.expireAfter) {
             return this.expire();
         } else if (idleFor >= this.warnAfter) {
-            if (!this.counterStarted && this.secondsElementID){
+            if (!this.counterStarted && this.counterElementID){
                 this.startCounter();
             }
             this.showWarning();
@@ -156,7 +156,7 @@ yourlabs.SessionSecurity.prototype = {
         let expireAfter = this.expireAfter;
         let warnAfter = this.warnAfter;
         let defaultTimeLeft = expireAfter - warnAfter;
-        let elementTarget = this.secondsElementID;
+        let elementTarget = this.counterElementID;
         let counterStarted = false;
         if (!this.counterStarted) {
             document.getElementById(elementTarget).innerHTML = defaultTimeLeft.toString();
@@ -179,7 +179,7 @@ yourlabs.SessionSecurity.prototype = {
       clearTimeout(this.counterTimeout);
       this.counterStarted = false;
       let defaultTimeLeft = this.expireAfter - this.warnAfter;
-      document.getElementById(this.secondsElementID).innerHTML = defaultTimeLeft.toString();
+      document.getElementById(this.counterElementID).innerHTML = defaultTimeLeft.toString();
     },
 
     // onbeforeunload handler.

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -178,6 +178,8 @@ yourlabs.SessionSecurity.prototype = {
     stopCounter: function(){
       clearTimeout(this.counterTimeout);
       this.counterStarted = false;
+      let defaultTimeLeft = this.expireAfter - this.warnAfter;
+      document.getElementById(this.secondsElementID).innerHTML = defaultTimeLeft.toString();
     },
 
     // onbeforeunload handler.

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -142,7 +142,9 @@ yourlabs.SessionSecurity.prototype = {
             nextPing = this.expireAfter - idleFor;
         } else {
             this.hideWarning();
-            this.stopCounter();
+            if (this.counterStarted && this.counterElementID){
+                this.stopCounter();
+            }
             nextPing = this.warnAfter - idleFor;
         }
 

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -159,7 +159,7 @@ yourlabs.SessionSecurity.prototype = {
         let spanTarget = this.secondsSpanID;
         let counterStarted = false;
         if (!this.counterStarted) {
-            document.getElementById(spanTarget).innerHTML = " in " + defaultTimeLeft.toString() + " seconds";
+            document.getElementById(spanTarget).innerHTML = defaultTimeLeft.toString();
             counterStarted = true;
         }
         var t = new Date();
@@ -169,7 +169,7 @@ yourlabs.SessionSecurity.prototype = {
             var distance = t - now;
             var seconds = Math.floor((distance % (1000 * expireAfter)) / 1000);
             if (distance > 0) {
-                document.getElementById(spanTarget).innerHTML = " in " + seconds.toString() + " seconds";
+                document.getElementById(spanTarget).innerHTML = seconds.toString();
             }
         }, 1000);
         this.counterStarted = counterStarted;

--- a/session_security/static/session_security/script.js
+++ b/session_security/static/session_security/script.js
@@ -135,7 +135,7 @@ yourlabs.SessionSecurity.prototype = {
         if (idleFor >= this.expireAfter) {
             return this.expire();
         } else if (idleFor >= this.warnAfter) {
-            if (!this.counterStarted && this.secondsSpanID){
+            if (!this.counterStarted && this.secondsElementID){
                 this.startCounter();
             }
             this.showWarning();
@@ -156,10 +156,10 @@ yourlabs.SessionSecurity.prototype = {
         let expireAfter = this.expireAfter;
         let warnAfter = this.warnAfter;
         let defaultTimeLeft = expireAfter - warnAfter;
-        let spanTarget = this.secondsSpanID;
+        let elementTarget = this.secondsElementID;
         let counterStarted = false;
         if (!this.counterStarted) {
-            document.getElementById(spanTarget).innerHTML = defaultTimeLeft.toString();
+            document.getElementById(elementTarget).innerHTML = defaultTimeLeft.toString();
             counterStarted = true;
         }
         var t = new Date();
@@ -169,7 +169,7 @@ yourlabs.SessionSecurity.prototype = {
             var distance = t - now;
             var seconds = Math.floor((distance % (1000 * expireAfter)) / 1000);
             if (distance > 0) {
-                document.getElementById(spanTarget).innerHTML = seconds.toString();
+                document.getElementById(elementTarget).innerHTML = seconds.toString();
             }
         }, 1000);
         this.counterStarted = counterStarted;


### PR DESCRIPTION
This adds a counter to count down the number of seconds remaining until expiration if counterElementID is set, e.g.:

```
<h3>{% trans 'Your session is about to expire in' %} <span id="in_seconds"></span> {% trans 'seconds' %}</h3>

<script type="text/javascript">
            var sessionSecurity = new yourlabs.SessionSecurity({
                pingUrl: '{% url 'session_security_ping' %}',
                warnAfter: {{ request|warn_after|unlocalize }},
                expireAfter: {{ request|expire_after|unlocalize }},
                confirmFormDiscard: "{% trans 'You have unsaved changes in a form of this page.' %}",
                counterElementID: "in_seconds"
            });
        </script>
```
![image](https://user-images.githubusercontent.com/1222343/87110341-cb1d3b80-c234-11ea-97f9-0f93bc322ff2.png)
