### PR TITLE
Django 3 deprecation warnings

### DIFF
--- a/session_security/urls.py
+++ b/session_security/urls.py
@@ -15,9 +15,12 @@ ie::
 
 """
 try:
-    from django.conf.urls import url
+    from django.urls import re_path as url
 except ImportError:
-    from django.conf.urls.defaults import url
+    try:
+        from django.conf.urls import url
+    except ImportError:
+        from django.conf.urls.defaults import url
 
 from .views import PingView
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py{27,35,36}-django{18,19,110,111}
     py{35,36,37,38}-django{111,20}
-    py{36,37,38}-django{3}
+    py{36,37,38}-django{30,31,32}
 [testenv]
 usedevelop = true
 commands =
@@ -15,7 +15,9 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11a1
     django20: Django >=2.0.0,<3.0.0
-    django3: Django >=3.0.0
+    django30: Django >=3.0,<3.1
+    django31: Django >=3.1,<3.2
+    django32: Django >=3.2
 setenv =
     PIP_ALLOW_EXTERNAL=true
     DJANGO_SETTINGS_MODULE=session_security.tests.project.settings


### PR DESCRIPTION
Hi,

Using the latest version in projects with Django 3.1 or newer results in the following warning:
```
RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
```

This resolves that warning and also adds 3.1 and 3.2 to the test matrix.