### PR TITLE
do not use style-tags to prevent csp of unsafe-inline

### DIFF
--- a/session_security/static/session_security/style.css
+++ b/session_security/static/session_security/style.css
@@ -25,6 +25,6 @@
     text-align: center;
 }
 
-.session_security {
+.session_security_hidden {
     display: none;
 }

--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -40,7 +40,7 @@ It provides sensible defaults so you could start with just::
     {# Hidden POST form for logout — required by Django 5.x (LogoutView no longer accepts GET) #}
     {% with redirect_to_logout=request|redirect_to_logout %}
     {% if redirect_to_logout %}
-    <form id="session_security_logout_form" action="{% url 'logout' %}" method="post" style="display:none">
+    <form id="session_security_logout_form" action="{% url 'logout' %}" method="post" class="session_security_hidden">
         {% csrf_token %}
     </form>
     {% endif %}

--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -25,7 +25,7 @@ It provides sensible defaults so you could start with just::
     {# Bootstrap a SessionSecurity instance as the sessionSecurity global variable #}
     {% with redirect_to_logout_flag=request|redirect_to_logout %}
     {% localize off %}
-        <script type="text/javascript"{% if csp_nonce is not None %} nonce="{{ csp_nonce }}"{% elif request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %}>
+        <script type="text/javascript" nonce="{% if request.csp_nonce %}{{ request.csp_nonce }}{% else %}{{ csp_nonce }}{% endif %}">
             var sessionSecurity = new yourlabs.SessionSecurity({
                 pingUrl: '{% url 'session_security_ping' %}',
                 warnAfter: {{ request|warn_after|unlocalize }},

--- a/session_security/templates/session_security/all.html
+++ b/session_security/templates/session_security/all.html
@@ -25,7 +25,7 @@ It provides sensible defaults so you could start with just::
     {# Bootstrap a SessionSecurity instance as the sessionSecurity global variable #}
     {% with redirect_to_logout_flag=request|redirect_to_logout %}
     {% localize off %}
-        <script type="text/javascript"{% if request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %}>
+        <script type="text/javascript"{% if csp_nonce is not None %} nonce="{{ csp_nonce }}"{% elif request.csp_nonce %} nonce="{{ request.csp_nonce }}"{% endif %}>
             var sessionSecurity = new yourlabs.SessionSecurity({
                 pingUrl: '{% url 'session_security_ping' %}',
                 warnAfter: {{ request|warn_after|unlocalize }},

--- a/session_security/templates/session_security/dialog.html
+++ b/session_security/templates/session_security/dialog.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div id="session_security_warning" class="session_security" aria-hidden="true" role="dialog">
+<div id="session_security_warning" class="session_security_hidden" aria-hidden="true" role="dialog">
     <div class="session_security_overlay"></div>
     <div class="session_security_modal" role="document" tabindex="-1">
         <h3>{% trans 'Your session is about to expire' %}: <span id="session_security_counter"></span> {% trans 'seconds' %}</h3>


### PR DESCRIPTION
To support the use of [Content-Security-Policys](https://developer.mozilla.org/de/docs/Web/HTTP/Guides/CSP) using style-attributes should be avoided, as they require a CSP of `unsafe-inline` which might be not wanted by the user. As we already provide a class to hide content we can easily use it.

This MR also adds support for the django-included csp-module. At the time of #158 there only was django-csp, but django uses a different variable name which is evaluated lazy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Consolidated hidden-element styling into a dedicated CSS class for cleaner presentation.

* **Refactor**
  * Updated templates to use the new CSS class instead of inline styles for controlling element visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->